### PR TITLE
Fix YouTube error message

### DIFF
--- a/public/page2.js
+++ b/public/page2.js
@@ -36,7 +36,8 @@ ytForm.addEventListener('submit', async (e) => {
     if (!res.ok) {
       let msg = '请求失败';
       try {
-        const data = await res.json();
+        const clone = res.clone();
+        const data = await clone.json();
         msg = data.error || msg;
       } catch {
         msg = await res.text();


### PR DESCRIPTION
## Summary
- fix YouTube video page error handler so we only read the response body once

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684564e5aa20832fb1b457c2f9720b82