### PR TITLE
Fix long video timeouts

### DIFF
--- a/api/youtube.js
+++ b/api/youtube.js
@@ -24,17 +24,21 @@ export default async function handler(req, res) {
 
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const genModel = genAI.getGenerativeModel({ model });
+    const requestOpts = { timeout: 600000 };
+    const genModel = genAI.getGenerativeModel({ model }, requestOpts);
 
     // 生成内容
-    const result = await genModel.generateContent([
-      prompt,
-      {
-        fileData: {
-          fileUri: url,
+    const result = await genModel.generateContent(
+      [
+        prompt,
+        {
+          fileData: {
+            fileUri: url,
+          },
         },
-      },
-    ]);
+      ],
+      requestOpts
+    );
     const text = result.response.text();
 
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');

--- a/server.js
+++ b/server.js
@@ -67,6 +67,12 @@ const server = app.listen(PORT, () =>
   console.log(`✔️  jina-reader-app listening on http://localhost:${PORT}`)
 );
 
+// 防止 Node 在长时间处理时自动关闭连接
+server.setTimeout(0);
+server.headersTimeout = 0;
+server.requestTimeout = 0;
+server.keepAliveTimeout = 65 * 1000;
+
 server.on('error', (err) => {
   if (err.code === 'EADDRINUSE') {
     console.error(`❌ 端口 ${PORT} 已被占用，请更换端口或关闭占用该端口的进程后重试。`);


### PR DESCRIPTION
## Summary
- disable server timeouts so long requests don't close
- allow longer Google API requests when processing YouTube videos

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68462228d5a0832fa6cf2267ea0e2974