### PR TITLE
Fix navigation layout and blog date parsing

### DIFF
--- a/public/page1.js
+++ b/public/page1.js
@@ -28,8 +28,11 @@ export default function initPage1() {
       const block = document.createElement('div');
       block.className = 'blog-block';
 
-      // 从时间戳创建日期字符串
-      const date = blog.createdAt ? new Date(Number(blog.createdAt)) : new Date();
+      // 根据返回的 createdAt 解析日期
+      const rawDate = blog.createdAt;
+      const date = rawDate
+        ? new Date(isNaN(rawDate) ? rawDate : Number(rawDate))
+        : new Date();
       const dateStr = date.toLocaleDateString('zh-CN', {
         year: 'numeric',
         month: '2-digit',

--- a/public/styles.css
+++ b/public/styles.css
@@ -633,7 +633,7 @@ button:active:not(:disabled) {
 /* 响应式调整 */
 @media (max-width: 768px) {
   .navbar {
-    flex-direction: column;
+    flex-direction: row; /* 保持在移动端也为横向排列 */
     padding: 1em;
   }
 


### PR DESCRIPTION
## Summary
- keep navbar horizontal on small screens
- correctly parse ISO strings or timestamps for blog `createdAt`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846e52d5950832f9ae1d0e662514362