### PR TITLE
Enable editing of fetched text

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -17,10 +17,13 @@ export default function initHome() {
   const btnOpenSite = document.getElementById('btn-open-site');
   const btnAIClean = document.getElementById('btn-ai-clean');
   const btnToggleRaw = document.getElementById('btn-toggle-raw');
+  const btnEdit = document.getElementById('btn-edit');
+  const outputEditor = document.getElementById('output-editor');
 
   let rawMarkdown = '';
   let aiMarkdown = '';
   let showingAI = false;
+  let editing = false;
 
   // 初始化提示词输入框
   if (extraInput) {
@@ -80,6 +83,9 @@ export default function initHome() {
         output.innerHTML = window.marked ? window.marked.parse(aiMarkdown) : aiMarkdown;
         showingAI = true;
         btnToggleRaw.style.display = '';
+        if (outputEditor) outputEditor.style.display = 'none';
+        if (btnEdit) btnEdit.textContent = '编辑文本';
+        editing = false;
       } catch (err) {
         output.innerHTML = '❌ ' + err.message;
         aiMarkdown = '';
@@ -93,6 +99,10 @@ export default function initHome() {
   // 切换原文/AI按钮事件
   if (btnToggleRaw) {
     btnToggleRaw.addEventListener('click', () => {
+      if (editing) {
+        // 如果正在编辑，先退出编辑模式
+        btnEdit.click();
+      }
       if (showingAI) {
         output.innerHTML = window.marked ? window.marked.parse(rawMarkdown) : rawMarkdown;
         showingAI = false;
@@ -101,6 +111,32 @@ export default function initHome() {
         output.innerHTML = window.marked ? window.marked.parse(aiMarkdown) : aiMarkdown;
         showingAI = true;
         btnToggleRaw.textContent = '切换原文/AI';
+      }
+    });
+  }
+
+  // 编辑文本按钮事件
+  if (btnEdit && outputEditor) {
+    btnEdit.addEventListener('click', () => {
+      if (!editing) {
+        const text = showingAI ? aiMarkdown : rawMarkdown;
+        outputEditor.value = text;
+        output.style.display = 'none';
+        outputEditor.style.display = '';
+        btnEdit.textContent = '保存';
+        editing = true;
+      } else {
+        const newText = outputEditor.value;
+        if (showingAI) {
+          aiMarkdown = newText;
+        } else {
+          rawMarkdown = newText;
+        }
+        output.innerHTML = window.marked ? window.marked.parse(newText) : newText;
+        output.style.display = '';
+        outputEditor.style.display = 'none';
+        btnEdit.textContent = '编辑文本';
+        editing = false;
       }
     });
   }
@@ -142,6 +178,9 @@ export default function initHome() {
         aiMarkdown = '';
         showingAI = false;
         btnToggleRaw.style.display = 'none';
+        if (outputEditor) outputEditor.style.display = 'none';
+        if (btnEdit) btnEdit.textContent = '编辑文本';
+        editing = false;
       } catch (err) {
         output.innerHTML = `❌ 出错：${err.message}`;
         rawMarkdown = '';
@@ -160,7 +199,11 @@ export default function initHome() {
       }
       try {
         // 复制当前显示内容（不加提示词）
-        const text = showingAI ? aiMarkdown : rawMarkdown;
+        const text = editing
+          ? outputEditor.value
+          : showingAI
+            ? aiMarkdown
+            : rawMarkdown;
         await navigator.clipboard.writeText(text);
         btnCopy.textContent = '已复制 ✅';
         setTimeout(() => (btnCopy.textContent = '复制文本'), 1500);
@@ -187,6 +230,9 @@ export default function initHome() {
         btnToggleRaw.style.display = 'none'; // 隐藏切换按钮
         btnToggleRaw.textContent = '切换原文/AI';
       }
+      if (outputEditor) outputEditor.style.display = 'none';
+      if (btnEdit) btnEdit.textContent = '编辑文本';
+      editing = false;
       if (blogTitleInput) {
         blogTitleInput.value = ''; // 清空博客标题
       }
@@ -218,7 +264,11 @@ export default function initHome() {
         blogTitleInput.focus();
         return;
       }
-      const content = showingAI ? aiMarkdown : rawMarkdown;
+      const content = editing
+        ? outputEditor.value
+        : showingAI
+          ? aiMarkdown
+          : rawMarkdown;
       if (!content) {
         alert('没有可保存的内容');
         return;

--- a/public/pages/home.html
+++ b/public/pages/home.html
@@ -33,12 +33,13 @@
   </section>
 
   <section id="controls" class="controls-section" hidden>
-    <div class="button-group primary-actions">
-      <button id="btn-copy">复制文本</button>
-      <button id="btn-clear">清空</button>
-      <button id="btn-ai-clean">AI清理</button>
-      <button id="btn-toggle-raw" style="display:none;">切换原文/AI</button>
-    </div>
+      <div class="button-group primary-actions">
+        <button id="btn-copy">复制文本</button>
+        <button id="btn-clear">清空</button>
+        <button id="btn-ai-clean">AI清理</button>
+        <button id="btn-edit" type="button">编辑文本</button>
+        <button id="btn-toggle-raw" style="display:none;">切换原文/AI</button>
+      </div>
     
     <div class="blog-controls">
       <input id="blog-title" type="text" placeholder="博客标题" />
@@ -46,9 +47,10 @@
     </div>
   </section>
 
-  <section id="output-wrapper" class="output-section">
-    <div id="output"></div>
-  </section>
+    <section id="output-wrapper" class="output-section">
+      <div id="output"></div>
+      <textarea id="output-editor" class="output-editor" style="display:none;"></textarea>
+    </section>
 </main>
 
 <footer>

--- a/public/styles.css
+++ b/public/styles.css
@@ -190,6 +190,18 @@ button:active:not(:disabled) {
   line-height: 1.7;
   overflow-x: auto;
 }
+
+#output-editor {
+  width: 100%;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  min-height: 120px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--gap);
+  box-sizing: border-box;
+  resize: vertical;
+}
 #output h1, #output h2, #output h3, #output h4, #output h5, #output h6 {
   margin: 1em 0 0.5em 0;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- add an Edit button to the home page and textarea for editing
- support editing of fetched/AI content and use edited text in later actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a967e6c34832fb2f56f8ed5525151