### PR TITLE
Add model selection dropdown for Gemini

### DIFF
--- a/api/gemini.js
+++ b/api/gemini.js
@@ -3,6 +3,12 @@ dotenv.config();
 
 import { GoogleGenAI, HarmBlockThreshold, HarmCategory } from '@google/genai';
 
+const ALLOWED_MODELS = [
+  'gemini-2.5-pro-preview-06-05',
+  'gemini-2.5-flash-preview-05-20'
+];
+const DEFAULT_MODEL = ALLOWED_MODELS[0];
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method Not Allowed' });
@@ -36,7 +42,7 @@ export default async function handler(req, res) {
       ],
       responseMimeType: 'text/plain',
     };
-    const useModel = model || 'gemini-2.5-pro-preview-06-05';
+    const useModel = ALLOWED_MODELS.includes(model) ? model : DEFAULT_MODEL;
     const contents = [
       { role: 'user', parts: [{ text: prompt }] }
     ];

--- a/public/main.js
+++ b/public/main.js
@@ -16,6 +16,7 @@ export default function initHome() {
   const siteSelect = document.getElementById('site-select');
   const btnOpenSite = document.getElementById('btn-open-site');
   const btnAIClean = document.getElementById('btn-ai-clean');
+  const aiModelSelect = document.getElementById('ai-model');
   const btnToggleRaw = document.getElementById('btn-toggle-raw');
 
   let rawMarkdown = '';
@@ -58,7 +59,8 @@ export default function initHome() {
             'Authorization': 'Bearer ' + authToken
           },
           body: JSON.stringify({
-            prompt: userInput
+            prompt: userInput,
+            model: aiModelSelect ? aiModelSelect.value : undefined
           })
         });
         if (!res.ok) {

--- a/public/pages/home.html
+++ b/public/pages/home.html
@@ -33,6 +33,13 @@
   </section>
 
   <section id="controls" class="controls-section" hidden>
+    <div class="model-select-row">
+      <label for="ai-model" class="section-label">选择模型:</label>
+      <select id="ai-model" class="model-select">
+        <option value="gemini-2.5-pro-preview-06-05">Gemini 2.5 Pro</option>
+        <option value="gemini-2.5-flash-preview-05-20">Gemini 2.5 Flash</option>
+      </select>
+    </div>
     <div class="button-group primary-actions">
       <button id="btn-copy">复制文本</button>
       <button id="btn-clear">清空</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -277,7 +277,17 @@ button:active:not(:disabled) {
   max-width: 400px; /* 可以设置一个最大宽度，防止过宽 */
 }
 
-#yt-prompt, #yt-model {
+.model-select {
+  height: 2.6em;
+  font-size: 1em;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 0 0.7em;
+  background: #fff;
+  max-width: 400px;
+}
+
+#yt-prompt, #yt-model, #ai-model {
   height: 2.6em;
   font-size: 1em;
 }
@@ -382,6 +392,12 @@ button:active:not(:disabled) {
 }
 
 .site-select-row {
+  display: flex;
+  gap: 0.8em;
+  align-items: center;
+}
+
+.model-select-row {
   display: flex;
   gap: 0.8em;
   align-items: center;


### PR DESCRIPTION
## Summary
- support multiple Gemini models in API handler
- add model selection dropdown on home page
- send selected model when requesting Gemini clean
- style model dropdown

## Testing
- `node -c api/gemini.js`
- `node -c public/main.js`
- `npm run -s test` *(fails: no test script)*
- `PORT=3001 npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ad13c7a48832f87cbe83d00f8da67