### PR TITLE
Switch auth page to login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
       <a href="#page1" class="nav-link" data-page="page1">博客</a>
       <a href="#home" class="nav-link active" data-page="home">网页</a>
       <a href="#page3" class="nav-link" data-page="page3">笔记</a>
-      <a href="#auth" class="nav-link nav-auth" data-page="auth">验</a>
+      <a href="#login" class="nav-link nav-login" data-page="login">登录</a>
     </nav>
     <div id="app"></div>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/public/login.js
+++ b/public/login.js
@@ -1,7 +1,7 @@
-export default function initAuth() {
-// 只负责身份认证
-let authToken = localStorage.getItem('authToken') || '';
-let isAuthed = false;
+export default function initLogin() {
+  // 只负责身份认证
+  let authToken = localStorage.getItem('authToken') || '';
+  let isAuthed = false;
 
 const authDiv = document.createElement('div');
 authDiv.className = 'auth-div';
@@ -18,6 +18,7 @@ if (authSection) {
 const authInput = document.getElementById('auth-password');
 const authBtn = document.getElementById('auth-login');
 const authStatus = document.getElementById('auth-status');
+const loginLink = document.querySelector('.nav-login');
 
 async function tryLogin(pwd) {
   authStatus.textContent = '正在验证...';
@@ -35,6 +36,11 @@ async function tryLogin(pwd) {
       authStatus.textContent = '登录成功';
       authInput.disabled = true;
       authBtn.disabled = true;
+      // 登录成功后隐藏登录链接并跳转主页
+      if (loginLink) loginLink.style.display = 'none';
+      setTimeout(() => {
+        location.hash = '#home';
+      }, 300);
     } else {
       throw new Error(data.error || '密码错误');
     }
@@ -56,3 +62,4 @@ if (authToken) {
   tryLogin(authToken);
 }
 }
+

--- a/public/main.js
+++ b/public/main.js
@@ -58,7 +58,7 @@ export default function initHome() {
       try {
         const authToken = localStorage.getItem('authToken') || '';
         if (!authToken) {
-          throw new Error('请先在“身份验证”页面登录');
+          throw new Error('请先登录后再操作');
         }
         const extraPrompt = extraInput.value || '';
         
@@ -141,7 +141,7 @@ export default function initHome() {
       // 检查本地 token
       const authToken = localStorage.getItem('authToken') || '';
       if (!authToken) {
-        alert('请先在“身份验证”页面登录');
+        alert('请先登录后再操作');
         return;
       }
       output.innerHTML = '⏳ 正在加载...';
@@ -188,7 +188,7 @@ export default function initHome() {
     btnCopy.addEventListener('click', async () => {
       const authToken = localStorage.getItem('authToken') || '';
       if (!authToken) {
-        alert('请先在“身份验证”页面登录');
+        alert('请先登录后再操作');
         return;
       }
       try {
@@ -248,7 +248,7 @@ export default function initHome() {
     btnCreateBlog.addEventListener('click', async () => {
       const authToken = localStorage.getItem('authToken') || '';
       if (!authToken) {
-        alert('请先在“身份验证”页面登录');
+        alert('请先登录后再操作');
         return;
       }
       const title = blogTitleInput.value.trim();

--- a/public/page2.js
+++ b/public/page2.js
@@ -17,7 +17,7 @@ ytForm.addEventListener('submit', async (e) => {
 
   const authToken = localStorage.getItem('authToken') || '';
   if (!authToken) {
-    ytOutput.innerHTML = '请先在“身份验证”页面登录';
+    ytOutput.innerHTML = '请先登录后再操作';
     ytGenerate.disabled = false;
     return;
   }
@@ -94,7 +94,7 @@ if (ytBtnCreateBlog) {
   ytBtnCreateBlog.addEventListener('click', async () => {
     const authToken = localStorage.getItem('authToken') || '';
     if (!authToken) {
-      alert('请先在“身份验证”页面登录');
+      alert('请先登录后再操作');
       return;
     }
     const title = ytBlogTitle.value.trim();

--- a/public/page3.js
+++ b/public/page3.js
@@ -29,7 +29,7 @@ export default function initPage3() {
     e.preventDefault();
     const authToken = localStorage.getItem('authToken') || '';
     if (!authToken) {
-      alert('请先在“身份验证”页面登录');
+      alert('请先登录后再操作');
       return;
     }
     const title = titleInput.value.trim();

--- a/public/pages/login.html
+++ b/public/pages/login.html
@@ -1,5 +1,5 @@
     <header>
-      <h1>身份验证</h1>
+      <h1>登录</h1>
     </header>
     <main>
       <section id="auth-section"></section>

--- a/public/router.js
+++ b/public/router.js
@@ -5,7 +5,7 @@ const routes = {
   page1: { path: 'pages/page1.html', script: './page1.js' },
   page2: { path: 'pages/page2.html', script: './page2.js' },
   page3: { path: 'pages/page3.html', script: './page3.js' },
-  auth: { path: 'pages/auth.html', script: './auth.js' }
+  login: { path: 'pages/login.html', script: './login.js' }
 };
 
 function getPage() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -258,7 +258,7 @@ button:hover:not(:disabled) {
   color: #fff !important;
 }
 
-.nav-auth {
+.nav-login {
   margin-left: auto;
   color: #ff6600;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- rename **auth** page and script to **login**
- update router and navigation links
- hide login link and redirect to home after successful login
- tweak text to mention logging in first

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b994bc890832faf9e5154fbbf2b58