### PR TITLE
Remove authentication checks in content pages

### DIFF
--- a/api/blog.js
+++ b/api/blog.js
@@ -1,7 +1,5 @@
 import fs from 'fs/promises';
 import path from 'path';
-import dotenv from 'dotenv';
-dotenv.config();
 
 const BLOG_DIR = path.resolve(process.cwd(), 'data/blogs');
 
@@ -9,18 +7,11 @@ async function ensureDir() {
   await fs.mkdir(BLOG_DIR, { recursive: true });
 }
 
-function checkAuth(req) {
-  const auth = req.headers.authorization || '';
-  const token = auth.replace(/^Bearer\s+/i, '');
-  return token && String(token) === process.env.AUTH_PASSWORD;
-}
-
 export default async function handler(req, res) {
   await ensureDir();
 
   // 新增文章
   if (req.method === 'POST') {
-    if (!checkAuth(req)) return res.status(401).json({ error: '未授权' });
     const { title, content, id: providedId } = req.body || {}; // Allow providing an ID
     if (!title || !content) return res.status(400).json({ error: '缺少标题或内容' });
     const id = providedId || Date.now().toString(); // Use provided ID or generate a new one
@@ -64,7 +55,6 @@ export default async function handler(req, res) {
 
   // 删除文章
   if (req.method === 'DELETE') {
-    if (!checkAuth(req)) return res.status(401).json({ error: '未授权' });
     const id = req.url.split('/').pop();
     if (!id) return res.status(400).json({ error: '缺少id' });
     await fs.rm(path.join(BLOG_DIR, id + '.json'), { force: true });

--- a/api/gemini.js
+++ b/api/gemini.js
@@ -14,13 +14,6 @@ export default async function handler(req, res) {
     res.status(405).json({ error: 'Method Not Allowed' });
     return;
   }
-  // 简单认证
-  const auth = req.headers.authorization || '';
-  const token = auth.replace(/^Bearer\s+/i, '');
-  if (!token || String(token) !== process.env.AUTH_PASSWORD) {
-    res.status(401).json({ error: '未授权，请先登录' });
-    return;
-  }
 
   const { messages, model } = req.body || {};
   if (!messages || !Array.isArray(messages) || messages.length === 0) {

--- a/api/openai.js
+++ b/api/openai.js
@@ -14,12 +14,6 @@ export default async function handler(req, res) {
     res.status(405).json({ error: 'Method Not Allowed' });
     return;
   }
-  const auth = req.headers.authorization || '';
-  const token = auth.replace(/^Bearer\s+/i, '');
-  if (!token || String(token) !== process.env.AUTH_PASSWORD) {
-    res.status(401).json({ error: '未授权，请先登录' });
-    return;
-  }
 
   // Per the user's example, we expect a conversational history.
   // The standard parameter name is `messages`, which we'll use.

--- a/api/youtube.js
+++ b/api/youtube.js
@@ -8,13 +8,6 @@ export default async function handler(req, res) {
     res.status(405).json({ error: 'Method Not Allowed' });
     return;
   }
-  // 简单认证
-  const auth = req.headers.authorization || '';
-  const token = auth.replace(/^Bearer\s+/i, '');
-  if (!token || String(token) !== process.env.AUTH_PASSWORD) {
-    res.status(401).json({ error: '未授权，请先登录' });
-    return;
-  }
 
   const { url, prompt, model } = req.body || {};
   if (!url || !prompt || !model) {

--- a/public/page1.js
+++ b/public/page1.js
@@ -2,13 +2,10 @@ import { formatDate } from './utils/dateFormat.js';
 
 export default function initPage1() {
   const blogList = document.getElementById('blog-list');
-  const authToken = localStorage.getItem('authToken') || '';
 
   async function fetchBlogs() {
     try {
-      const res = await fetch('/api/blog', {
-        headers: { 'Authorization': 'Bearer ' + authToken }
-      });
+      const res = await fetch('/api/blog');
       const data = await res.json();
       console.log('获取到的博客数据:', data.blogs); // 调试用
       renderBlogs(data.blogs || []);
@@ -131,8 +128,7 @@ export default function initPage1() {
       deleteIcon.onclick = async () => {
         if (!confirm('确定要删除这篇文章吗？')) return;
         const res = await fetch(`/api/blog/${encodeURIComponent(blog.id)}`, {
-          method: 'DELETE',
-          headers: { 'Authorization': 'Bearer ' + authToken }
+          method: 'DELETE'
         });
         if (res.ok) fetchBlogs();
         else alert('删除失败');

--- a/public/page2.js
+++ b/public/page2.js
@@ -15,19 +15,12 @@ ytForm.addEventListener('submit', async (e) => {
   ytOutput.innerHTML = '⏳ 正在生成...';
   ytGenerate.disabled = true;
 
-  const authToken = localStorage.getItem('authToken') || '';
-  if (!authToken) {
-    ytOutput.innerHTML = '请先登录后再操作';
-    ytGenerate.disabled = false;
-    return;
-  }
 
   try {
     const res = await fetch('/api/youtube', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + authToken
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({
         url: ytUrl.value.trim(),
@@ -92,11 +85,6 @@ const ytBtnCreateBlog = document.getElementById('yt-btn-create-blog');
 
 if (ytBtnCreateBlog) {
   ytBtnCreateBlog.addEventListener('click', async () => {
-    const authToken = localStorage.getItem('authToken') || '';
-    if (!authToken) {
-      alert('请先登录后再操作');
-      return;
-    }
     const title = ytBlogTitle.value.trim();
     if (!title) {
       alert('请输入博客标题');
@@ -115,8 +103,7 @@ if (ytBtnCreateBlog) {
       const res = await fetch('/api/blog', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer ' + authToken
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({ title, content, createdAt })
       });

--- a/public/page3.js
+++ b/public/page3.js
@@ -27,11 +27,6 @@ export default function initPage3() {
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const authToken = localStorage.getItem('authToken') || '';
-    if (!authToken) {
-      alert('请先登录后再操作');
-      return;
-    }
     const title = titleInput.value.trim();
     const content = contentInput.value.trim();
     if (!title || !content) {
@@ -47,8 +42,7 @@ export default function initPage3() {
       if (isEditing) {
         // Step 1: Delete the old file
         const deleteRes = await fetch(`/api/blog/${encodeURIComponent(editingBlogId)}`, {
-          method: 'DELETE',
-          headers: { 'Authorization': 'Bearer ' + authToken }
+          method: 'DELETE'
         });
 
         if (!deleteRes.ok) {
@@ -60,8 +54,7 @@ export default function initPage3() {
         const createRes = await fetch('/api/blog', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + authToken
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ id: editingBlogId, title, content })
         });
@@ -79,8 +72,7 @@ export default function initPage3() {
         const res = await fetch('/api/blog', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + authToken
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ title, content })
         });


### PR DESCRIPTION
## Summary
- drop token checks in API handlers
- allow blog and AI endpoints to work without Authorization headers
- simplify frontend fetch calls to omit Authorization header

## Testing
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684bba324404832f9368028158297021